### PR TITLE
Fix dark mode toggle text color

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,6 +343,7 @@ img.bg {
 	  for (var i = 0; i < x.length; i++) {
 	    if (x[i].className != "fg" && x[i].className != "bg") {
 	      x[i].style.background = "#fbfcff";
+		  x[i].style.color = "#243b4a";
 	    }
 	  }
 	  dark = 0;
@@ -352,6 +353,7 @@ img.bg {
 	  for (var i = 0; i < x.length; i++) {
 	    if (x[i].className != "fg" && x[i].className != "bg") {
 	      x[i].style.background = "#111111";
+		  x[i].style.color = "#ffffff";
 	    }
 	  }
 	  dark = 1;


### PR DESCRIPTION
The existing dark mode toggle doesn't change the text color, making it difficult to see in dark mode due to low contrast.

Toggle the text color between white and the original color.